### PR TITLE
Replace all blank targets with _blank

### DIFF
--- a/public/components/sidebar.php
+++ b/public/components/sidebar.php
@@ -9,18 +9,18 @@
             <section class="switch news active">
                 <article>
                     <h3 class="bold">Follow & join us!</h3>
-                    <p>For networking there is a <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="blank">mailing list</a>, a <a href="https://matrix.to/#/#bitsundbaeume:matrix.org" target="blank">Matrix chat</a> and a <a href="https://discourse.bits-und-baeume.org" target="blank">discussion board</a>.
+                    <p>For networking there is a <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="_blank">mailing list</a>, a <a href="https://matrix.to/#/#bitsundbaeume:matrix.org" target="_blank">Matrix chat</a> and a <a href="https://discourse.bits-und-baeume.org" target="_blank">discussion board</a>.
                     </p>
                 </article>
 
                 <article>
                     <h3 class="bold">Diary</h3>
-                    <p>See our upcoming events <a href="https://discourse.bits-und-baeume.org/calendar" target="blank">here</a>.</p>
+                    <p>See our upcoming events <a href="https://discourse.bits-und-baeume.org/calendar" target="_blank">here</a>.</p>
                 </article>
 
                 <article>
                     <h3 class="bold">Publication: <em>Was Bits&Bäume verbindet</em></h3>
-                    <p>Our <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="blank">conference book</a> has been published pushing further the topics of the conference. Thanks to all crowdfunders!
+                    <p>Our <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="_blank">conference book</a> has been published pushing further the topics of the conference. Thanks to all crowdfunders!
                     </p>
                 </article>
 
@@ -58,18 +58,18 @@
             <section class="switch news active">
                 <article>
                     <h3 class="bold">Komm dazu!</h3>
-                    <p>Um uns zu vernetzen, haben wir eine <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="blank">Mailingliste</a>, einen <a href="https://matrix.to/#/#bitsundbaeume:matrix.org" target="blank">Matrix-Chat</a> und ein <a href="https://discourse.bits-und-baeume.org" target="blank">Diskussionsbrett</a>.
+                    <p>Um uns zu vernetzen, haben wir eine <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="_blank">Mailingliste</a>, einen <a href="https://matrix.to/#/#bitsundbaeume:matrix.org" target="_blank">Matrix-Chat</a> und ein <a href="https://discourse.bits-und-baeume.org" target="_blank">Diskussionsbrett</a>.
                     </p>
                 </article>
 
                 <article>
                     <h3 class="bold">Aktuelle Termine</h3>
-                    <p>Unser aktueller Terminkalender ist <a href="https://discourse.bits-und-baeume.org/calendar" target="blank">hier</a>.</p>
+                    <p>Unser aktueller Terminkalender ist <a href="https://discourse.bits-und-baeume.org/calendar" target="_blank">hier</a>.</p>
                 </article>
 
                 <article>
                     <h3 class="bold">Buch: <em>Was Bits&Bäume verbindet</em></h3>
-                    <p>Das <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="blank">Buch zur Konferenz</a> ist da. Dank an die successfully fundende Crowd!</p>
+                    <p>Das <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="_blank">Buch zur Konferenz</a> ist da. Dank an die successfully fundende Crowd!</p>
                 </article>
 
                 <article>

--- a/public/pages/material.php
+++ b/public/pages/material.php
@@ -22,7 +22,7 @@ article .row--forderung > p {
             <section>
               <p>You plan to organise a Bits&Bäume event, a round table, a conference, a discussion evening or a panel? Great!
               </p>
-              <p>You already know <a href="/waechst/<?php echo $lang; ?>" target="blank">what is important to us</a>, if you want to name your new branch <em>Bits&Bäume</em>? Even better!
+              <p>You already know <a href="/waechst/<?php echo $lang; ?>" target="_blank">what is important to us</a>, if you want to name your new branch <em>Bits&Bäume</em>? Even better!
               </p>
               <p>Here you find whatever you might need to plant your own Bits&Bäume seed.
               </p>
@@ -33,17 +33,17 @@ article .row--forderung > p {
             <section>
               <h2>organise sustainably</h2>
               <ul>
-                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="blank">tips of the B&B-Team</a> how to organise sustainably from using an open street map to hiring collectives for whatever you need</a>
+                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="_blank">tips of the B&B-Team</a> how to organise sustainably from using an open street map to hiring collectives for whatever you need</a>
                 </li>
               </ul>
 
               <h2>find input</h2>
               <ul>
-                <li>our B&B publication <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="blank"><em>Was Bits&Bäume verbindet</em></a> (in German)
+                <li>our B&B publication <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="_blank"><em>Was Bits&Bäume verbindet</em></a> (in German)
                 </li>
-                <li>the speakers of the Bits&Bäume 2018, listet in our <a href="https://fahrplan.bits-und-baeume.org/speakers.html" target="blank">fahrplan</a>
+                <li>the speakers of the Bits&Bäume 2018, listet in our <a href="https://fahrplan.bits-und-baeume.org/speakers.html" target="_blank">fahrplan</a>
                 </li>
-                <li><a href="https://media.ccc.de/c/bub2018" target="blank">recordings</a> of the 2018 conference and further talks on Bits&Bäume topics on <a href="https://media.ccc.de/search/?q=b%C3%A4ume" target="blank">media.ccc.de</a>
+                <li><a href="https://media.ccc.de/c/bub2018" target="_blank">recordings</a> of the 2018 conference and further talks on Bits&Bäume topics on <a href="https://media.ccc.de/search/?q=b%C3%A4ume" target="_blank">media.ccc.de</a>
                 </li>
                 <li>ask the Bits&Bäume team to explain the Bits&Bäume demands and why bit and tree belong together (mail address following!)
                 </li>
@@ -53,8 +53,8 @@ article .row--forderung > p {
               <ul>
                 <li>🗋 B&B-Logo solo: <a target="_blank" href="/downloads/B&B_Logo_RGB.pdf">[pdf/screen]</a> | <a target="_blank" href="/downloads/B&B_Logo_CMYK.pdf">[pdf/print]</a> | <a target="_blank" href="/downloads/B&B_Logo_RGB.svg">[svg/screen]</a> | <a target="_blank" href="/downloads/B&B_Logo_CMYK.eps">[eps/print]</a></li>
                 <li>🗋 B&B-Logo with German conference subtitle: <a target="_blank" href="/downloads/B&B_Logo_Unterzeile_RGB.pdf">[pdf/screen]</a> | <a target="_blank" href="/downloads/B&B_Logo_Unterzeile_CMYK.pdf">[pdf/print]</a> | <a target="_blank" href="/downloads/B&B_Logo_Unterzeile_CMYK.eps">[eps/print]</a></li>
-                <li>🗋 <a href="/downloads/BUB_Sticker_zeitlos.pdf" target="blank">B&B sticker</a> [pdf]</li>
-                <li>🗋 B&B demands as a brochure <a href="/downloads/BUB_Forderungen_A5_Einzelseiten.pdf" target="blank">single pages </a>| <a href="/downloads/BUB_Forderungen_A5_Doppelseiten_Bookletreihenfolge.pdf" target="blank">double pages for brochure printing</a> [pdf]</li>
+                <li>🗋 <a href="/downloads/BUB_Sticker_zeitlos.pdf" target="_blank">B&B sticker</a> [pdf]</li>
+                <li>🗋 B&B demands as a brochure <a href="/downloads/BUB_Forderungen_A5_Einzelseiten.pdf" target="_blank">single pages </a>| <a href="/downloads/BUB_Forderungen_A5_Doppelseiten_Bookletreihenfolge.pdf" target="_blank">double pages for brochure printing</a> [pdf]</li>
                 <li>🗋 <a target="_blank" href="/downloads/B&B_Plakat_DIN-A1_CC_181108.pdf">B&B poster</a> [pdf]</li>
                 <li>... more material <a target="_blank" href="https://gitlab.com/bub-berlin/media">for download here</a>.</li>
           </section>
@@ -80,27 +80,27 @@ break;
             <section>
               <p>Du willst eine eigene Veranstaltung, einen Stammtisch, eine Konferenz, einen Diskussionsabend, ein Panel im Sinne von Bits&Bäume organisieren? Großartig!
               </p>
-              <p>Du hast schon <a href=/waechst/<?php echo $lang; ?>" target="blank">gelesen, was für uns wichtig ist</a>, damit du deinen Zweig wirklich <em>Bits&Bäume</em> nennen kannst? Noch viel besser!
+              <p>Du hast schon <a href=/waechst/<?php echo $lang; ?>" target="_blank">gelesen, was für uns wichtig ist</a>, damit du deinen Zweig wirklich <em>Bits&Bäume</em> nennen kannst? Noch viel besser!
               </p>
               <p>Du suchst einfach nur nach Ideen für deine eigene Veranstaltung? Auch gut :)
               </p>
-              <p>Hier findest du Material von A wie Anreisekarte (siehe <a href="https://bits-und-baeume.org/infrastruktur/de" target="blank">nachhaltig organisieren</a>) bis Z wie zwitschern <a href="https://twitter.com/hashtag/bitsundbaeume">(#bitsundbäume)</a>
+              <p>Hier findest du Material von A wie Anreisekarte (siehe <a href="https://bits-und-baeume.org/infrastruktur/de" target="_blank">nachhaltig organisieren</a>) bis Z wie zwitschern <a href="https://twitter.com/hashtag/bitsundbaeume">(#bitsundbäume)</a>
               </p>
             </section>
             <section>
               <h2>Nachhaltig organisieren</h2>
               <ul>
-                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="blank">Tipps des B&B-Teams</a>, was nachhaltig organisieren alles heißen kann, von Kollektiven bis zur Open Street Map
+                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="_blank">Tipps des B&B-Teams</a>, was nachhaltig organisieren alles heißen kann, von Kollektiven bis zur Open Street Map
                 </li>
               </ul>
 
               <h2>Referent*innen und Themen finden</h2>
               <ul>
-                <li>B&B-Publikation <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="blank"><em>Was Bits&Bäume verbindet</em></a>: die Themen der Konferenz zum Nachlesen und Vertiefen
+                <li>B&B-Publikation <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="_blank"><em>Was Bits&Bäume verbindet</em></a>: die Themen der Konferenz zum Nachlesen und Vertiefen
                 </li>
-                <li>die Referent*innen der Bits&Bäume 2018 im <a href="https://fahrplan.bits-und-baeume.org/speakers.html" target="blank">Fahrplan</a> scouten
+                <li>die Referent*innen der Bits&Bäume 2018 im <a href="https://fahrplan.bits-und-baeume.org/speakers.html" target="_blank">Fahrplan</a> scouten
                 </li>
-                <li><a href="https://media.ccc.de/c/bub2018" target="blank">Aufzeichnungen</a> der Konferenz 2018 und anderer Vorträge rund um Bits&Bäume und verwandte Stichworte auf <a href="https://media.ccc.de/search/?q=b%C3%A4ume" target="blank">media.ccc.de</a> durchklicken
+                <li><a href="https://media.ccc.de/c/bub2018" target="_blank">Aufzeichnungen</a> der Konferenz 2018 und anderer Vorträge rund um Bits&Bäume und verwandte Stichworte auf <a href="https://media.ccc.de/search/?q=b%C3%A4ume" target="_blank">media.ccc.de</a> durchklicken
                 </li>
                 <li>das Bits&Bäume-Vortrags-Team anfragen, um die Ziele von Bits&Bäume und den Zusammenhang von Bit&Baum zu erklären (Mailadresse folgt!)
                 </li>
@@ -110,8 +110,8 @@ break;
               <ul>
                 <li>🗋 B&B-Logo Solo: <a target="_blank" href="/downloads/B&B_Logo_RGB.pdf">[pdf/screen]</a> | <a target="_blank" href="/downloads/B&B_Logo_CMYK.pdf">[pdf/print]</a> | <a target="_blank" href="/downloads/B&B_Logo_RGB.svg">[svg/screen]</a> | <a target="_blank" href="/downloads/B&B_Logo_CMYK.eps">[eps/print]</a></li>
                 <li>🗋 B&B-Logo mit Konferenz-Untertitel: <a target="_blank" href="/downloads/B&B_Logo_Unterzeile_RGB.pdf">[pdf/screen]</a> | <a target="_blank" href="/downloads/B&B_Logo_Unterzeile_CMYK.pdf">[pdf/print]</a> | <a target="_blank" href="/downloads/B&B_Logo_Unterzeile_CMYK.eps">[eps/print]</a></li>
-                <li>🗋 <a href="/downloads/BUB_Sticker_zeitlos.pdf" target="blank">B&B-Sticker [pdf]</a></li>
-                <li>🗋 B&B-Forderungen als Broschüre <a href="/downloads/BUB_Forderungen_A5_Einzelseiten.pdf" target="blank">Einzelseiten für die Druckerei </a>| <a href="/downloads/BUB_Forderungen_A5_Doppelseiten_Bookletreihenfolge.pdf" target="blank">Doppelseiten zum Selberdrucken</a> [pdf]</li>
+                <li>🗋 <a href="/downloads/BUB_Sticker_zeitlos.pdf" target="_blank">B&B-Sticker [pdf]</a></li>
+                <li>🗋 B&B-Forderungen als Broschüre <a href="/downloads/BUB_Forderungen_A5_Einzelseiten.pdf" target="_blank">Einzelseiten für die Druckerei </a>| <a href="/downloads/BUB_Forderungen_A5_Doppelseiten_Bookletreihenfolge.pdf" target="_blank">Doppelseiten zum Selberdrucken</a> [pdf]</li>
                 <li>🗋 <a target="_blank" href="/downloads/B&B_Plakat_DIN-A1_CC_181108.pdf">B&B-Plakat</a> [pdf]</li>
                 <li>... mehr Material <a target="_blank" href="https://gitlab.com/bub-berlin/media">zum Download hier</a>.</li>
               </ul>

--- a/public/pages/regionalzweige.php
+++ b/public/pages/regionalzweige.php
@@ -30,22 +30,22 @@
 
                 <section>
                     <ul>
-                        <li><a href="https://dresden.bits-und-baeume.org" target="blank">Bits & Bäume Dresden</a>
+                        <li><a href="https://dresden.bits-und-baeume.org" target="_blank">Bits & Bäume Dresden</a>
                             <br>Our first regular's round, initiated by the Faculty of Computer Science, TU Dresden, after two Bits&Bäume events on May 23rd and June 20th. Meeting at the University of Dresden.
                         </li>
-                        <li><a href="https://berlin.bits-und-baeume.org/" target="blank">Bits & Bäume Berlin</a>
-                            <br>B&B local platform, initiated by the ASta of TU Berlin. They organize events & workshops. The Berlin branch set up our <a href="https://discourse.bits-und-baeume.org/" target="blank">online discussion board</a> and an instance for <a href="https://mastodon.bits-und-baeume.org/">Mastodon</a> as an alternative to Twitter – yay!
+                        <li><a href="https://berlin.bits-und-baeume.org/" target="_blank">Bits & Bäume Berlin</a>
+                            <br>B&B local platform, initiated by the ASta of TU Berlin. They organize events & workshops. The Berlin branch set up our <a href="https://discourse.bits-und-baeume.org/" target="_blank">online discussion board</a> and an instance for <a href="https://mastodon.bits-und-baeume.org/">Mastodon</a> as an alternative to Twitter – yay!
                         </li>
-                        <li><a href="http://bits-und-baeume-hannover.org/" target="blank">Bits & Bäume Hannover</a>
+                        <li><a href="http://bits-und-baeume-hannover.org/" target="_blank">Bits & Bäume Hannover</a>
                             <br>Regular's round, initiated by Chaos macht Schule.
                         </li>
-                        <li><a href="https://plattform-n.org/project/bits-baeume-osnabrueck/" target="blank">Bits & Bäume Osnabrück</a>
+                        <li><a href="https://plattform-n.org/project/bits-baeume-osnabrueck/" target="_blank">Bits & Bäume Osnabrück</a>
                             <br>Local B&B group.
                         </li>                        
-                        <li><a href="https://dortmund.bits-und-baeume.org/" target="blank">Bits & Bäume Dortmund</a>
+                        <li><a href="https://dortmund.bits-und-baeume.org/" target="_blank">Bits & Bäume Dortmund</a>
                             <br>Local group, currently being established.
                         </li>                       
-                        <li><a href="https://koeln.bits-und-baeume.org/" target="blank">Bits & Bäume Köln</a>
+                        <li><a href="https://koeln.bits-und-baeume.org/" target="_blank">Bits & Bäume Köln</a>
                             <br>Local group, currently being established.
                         </li>
                         <li><a href="/waechst/<?php echo $lang; ?>">Who will be next? :)</a>
@@ -56,7 +56,7 @@
 
             <section>
                 <h2>No Bits&Bäume nearby?</h2>
-                <p>Found your own regular's round! In our section <a href="/waechst/en<?php echo $lang; ?>" target="blank"><em> Bits&Bäume movement</em></a>, you can read more about what to do to organize your own Bits&Bäume formats. There is also a <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="blank">mailing list</a> as well as an <a href="https://discourse.bits-und-baeume.org/" target=blank">online discussion board</a>.
+                <p>Found your own regular's round! In our section <a href="/waechst/en<?php echo $lang; ?>" target="_blank"><em> Bits&Bäume movement</em></a>, you can read more about what to do to organize your own Bits&Bäume formats. There is also a <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="_blank">mailing list</a> as well as an <a href="https://discourse.bits-und-baeume.org/" target=blank">online discussion board</a>.
                 </p>
             </section>
         </article>
@@ -76,22 +76,22 @@
 
                 <section>
                     <ul>
-                        <li><a href="https://dresden.bits-und-baeume.org" target="blank">Bits & Bäume Dresden</a>
+                        <li><a href="https://dresden.bits-und-baeume.org" target="_blank">Bits & Bäume Dresden</a>
                             <br>war der erste Stammtisch! :) Gegründet von der Fakultät Informatik der TU Dresden nach zwei eigenen Bits&Bäume-Veranstaltungen am 23. Mai und 20. Juni 2019. Trifft sich an der Uni Dresden.
                         </li>
-                        <li><a href="https://berlin.bits-und-baeume.org/" target="blank">Bits & Bäume Berlin</a>
+                        <li><a href="https://berlin.bits-und-baeume.org/" target="_blank">Bits & Bäume Berlin</a>
                             <br>Lokale Bits&Bäume Plattform gegründet vom AStA der TU Berlin. Es werden Veranstaltungen & Workshops organisiert. Die Berliner*innen haben das <a href="https://discourse.bits-und-baeume.org/" target=blank">Bits&Bäume-Online-Forum</a> und eine <a href="https://mastodon.bits-und-baeume.org/">Mastodon-Instanz als Twitter-Alternative</a> aufgesetzt. Danke! :)
                         </li>
-                        <li><a href="http://bits-und-baeume-hannover.org/" target="blank">Bits & Bäume Hannover</a>
-                            <br>entstanden aus einer regionalen Gruppe von <a href="https://ccc.de/schule" target="blank">Chaos macht Schule</a>. Trifft sich in den Räumen des CCC Hannover.
+                        <li><a href="http://bits-und-baeume-hannover.org/" target="_blank">Bits & Bäume Hannover</a>
+                            <br>entstanden aus einer regionalen Gruppe von <a href="https://ccc.de/schule" target="_blank">Chaos macht Schule</a>. Trifft sich in den Räumen des CCC Hannover.
                         </li>
-                        <li><a href="https://plattform-n.org/project/bits-baeume-osnabrueck/" target="blank">Bits & Bäume Osnabrück</a>
+                        <li><a href="https://plattform-n.org/project/bits-baeume-osnabrueck/" target="_blank">Bits & Bäume Osnabrück</a>
                             <br>Lokale Bits&Bäume-Gruppe.
                         </li>                     
-                        <li><a href="https://dortmund.bits-und-baeume.org/" target="blank">Bits & Bäume Dortmund</a>
+                        <li><a href="https://dortmund.bits-und-baeume.org/" target="_blank">Bits & Bäume Dortmund</a>
                             <br>Lokale Bits&Bäume-Gruppe, in Gründung.
                         </li>            
-                        <li><a href="https://koeln.bits-und-baeume.org/" target="blank">Bits & Bäume Köln</a>
+                        <li><a href="https://koeln.bits-und-baeume.org/" target="_blank">Bits & Bäume Köln</a>
                             <br>Lokale Bits&Bäume-Gruppe, in Gründung.
                         </li>     
                         <li><a href="/waechst/<?php echo $lang; ?>">Hier könnte dein Wohnort stehen! :)</a>
@@ -101,9 +101,9 @@
             </div>
             <section>
                 <h2>Noch kein Bits&Bäume-Sprössling in deiner Nähe?</h2>
-                <p>Dann gründe einen! Unter <a href="/waechst/<?php echo $lang; ?>" target="blank"><em> Bits&Bäume wächst</em></a> findest du die Bedingungen für eigene Bits&Bäume-Aktionen. Melde dich mit den guten Nachrichten, dass es Zuwachs gibt und wie mensch euch findet, unter <a href="mailto:bewegung@bits-und-baeume.org">bewegung@bits-und-baeume.org</a>, dann nehmen wir euch in die Liste auf.
+                <p>Dann gründe einen! Unter <a href="/waechst/<?php echo $lang; ?>" target="_blank"><em> Bits&Bäume wächst</em></a> findest du die Bedingungen für eigene Bits&Bäume-Aktionen. Melde dich mit den guten Nachrichten, dass es Zuwachs gibt und wie mensch euch findet, unter <a href="mailto:bewegung@bits-und-baeume.org">bewegung@bits-und-baeume.org</a>, dann nehmen wir euch in die Liste auf.
                 </p>
-                <p> Außerdem kannst du dich bei unserer <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="blank">Mailingliste</a> anmelden oder in unserem <a href="https://discourse.bits-und-baeume.org/" target=blank">Bits&Bäume-Online-Forum </a>aktiv werden und dich vernetzen.
+                <p> Außerdem kannst du dich bei unserer <a href="https://lists.posteo.de/listinfo/bitsundbaeume" target="_blank">Mailingliste</a> anmelden oder in unserem <a href="https://discourse.bits-und-baeume.org/" target=blank">Bits&Bäume-Online-Forum </a>aktiv werden und dich vernetzen.
                 </p>
             </section>
 

--- a/public/pages/waechst.php
+++ b/public/pages/waechst.php
@@ -29,21 +29,21 @@ article .row--forderung > p {
   
               <h2>Bits&Bäume roots</h2>
               <ul>
-                <li>our <a href="/forderungen/<?php echo $lang; ?>" target="blank">political demands!</a>
+                <li>our <a href="/forderungen/<?php echo $lang; ?>" target="_blank">political demands!</a>
                 </li>
-                <li><a href="https://media.ccc.de/c/bub2018" target="blank">recordings</a> of the 2018 conference on media.ccc.de – 1001 thanks to the <a href="https://c3voc.de/" target="blank">VOC</a>!
+                <li><a href="https://media.ccc.de/c/bub2018" target="_blank">recordings</a> of the 2018 conference on media.ccc.de – 1001 thanks to the <a href="https://c3voc.de/" target="_blank">VOC</a>!
                 </li>
-                <li>our conference publication <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="blank"><em>Was Bits&Bäume verbindet</em> (in German)</a>
+                <li>our conference publication <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="_blank"><em>Was Bits&Bäume verbindet</em> (in German)</a>
                 </li> 
               </ul>
               
                <h2>planting new trees</h2>
               <ul>
-                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="blank">organise sustainably</a>: tips of the B&B-Teams to organise conferences and smaller events sustainably
+                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="_blank">organise sustainably</a>: tips of the B&B-Teams to organise conferences and smaller events sustainably
                 </li> 
-                <li><a href="/material/<?php echo $lang; ?>" target="blank">B&B material for your own events (from logo to sticker)</a>
+                <li><a href="/material/<?php echo $lang; ?>" target="_blank">B&B material for your own events (from logo to sticker)</a>
                 </li> 
-                <li>growing branches: <a href="/regionalzweige/<?php echo $lang; ?>" target="blank">regular's rounds</a>
+                <li>growing branches: <a href="/regionalzweige/<?php echo $lang; ?>" target="_blank">regular's rounds</a>
                 </li>
               </ul>   
               
@@ -91,26 +91,26 @@ break;
           <div class="row">
             <section>
               <p>Wir Initiator*innen der ersten Bits&Bäume-Konferenz haben uns entschieden, <strong>die Idee der Bits & Bäume in die Freiheit zu entlassen, auf dass sie weiter wachsen und gedeihen kann.</strong></p>
-              <p>Über ein Jahr lang haben wir als Team aus 10 Organisationen daran gearbeitet, die Bits&Bäume 2018 aus der Taufe zu heben – das war sehr bereichernd für uns, aber auch viel Arbeit, gerade weil so unterschiedliche Organisationen an einem Tisch saßen. Wir bekommen viele freudige Hoffnungsbekundungen auf eine Wiederholung 2019, was uns sehr freut, allerdings können wir leider diese gemeinsame Arbeit nicht langfristig in unseren Arbeitsalltag integrieren. Aber die Bits & Bäume war auch eine <strong>Konferenz von uns allen für uns alle!</strong> Nehmt den Faden also doch einfach auf, gründet einen Stammtisch in eurer Stadt <a href="/regionalzweige/<?php echo $lang; ?>" target="blank">(hier siehst du, welche Stammtische es schon gibt)</a>, organisiert eine kleinere oder größere Veranstaltung, einen Diskussionsabend, erklärt auf Panels, warum und wie Digitalisierung und Nachhaltigkeit zusammengehören, lasst uns weiterhin unter <a href="https://twitter.com/hashtag/bitsundbaeume">#bitsundbäume</a> Ideen und Fortschritte austauschen, denkt euch neue Vernetzungsformate aus.</p>
+              <p>Über ein Jahr lang haben wir als Team aus 10 Organisationen daran gearbeitet, die Bits&Bäume 2018 aus der Taufe zu heben – das war sehr bereichernd für uns, aber auch viel Arbeit, gerade weil so unterschiedliche Organisationen an einem Tisch saßen. Wir bekommen viele freudige Hoffnungsbekundungen auf eine Wiederholung 2019, was uns sehr freut, allerdings können wir leider diese gemeinsame Arbeit nicht langfristig in unseren Arbeitsalltag integrieren. Aber die Bits & Bäume war auch eine <strong>Konferenz von uns allen für uns alle!</strong> Nehmt den Faden also doch einfach auf, gründet einen Stammtisch in eurer Stadt <a href="/regionalzweige/<?php echo $lang; ?>" target="_blank">(hier siehst du, welche Stammtische es schon gibt)</a>, organisiert eine kleinere oder größere Veranstaltung, einen Diskussionsabend, erklärt auf Panels, warum und wie Digitalisierung und Nachhaltigkeit zusammengehören, lasst uns weiterhin unter <a href="https://twitter.com/hashtag/bitsundbaeume">#bitsundbäume</a> Ideen und Fortschritte austauschen, denkt euch neue Vernetzungsformate aus.</p>
             </section>
             <section>   
               <h2>Was bleibt</h2>
               <ul>
-                <li>unsere <a href="/forderungen/<?php echo $lang; ?>" target="blank">Forderungen!</a>
+                <li>unsere <a href="/forderungen/<?php echo $lang; ?>" target="_blank">Forderungen!</a>
                 </li>
-                <li>die <a href="https://media.ccc.de/c/bub2018" target="blank">Aufzeichnungen</a> der Konferenz 2018 auf media.ccc.de – 1001 Dank ans <a href="https://c3voc.de/" target="blank">VOC</a>!
+                <li>die <a href="https://media.ccc.de/c/bub2018" target="_blank">Aufzeichnungen</a> der Konferenz 2018 auf media.ccc.de – 1001 Dank ans <a href="https://c3voc.de/" target="_blank">VOC</a>!
                 </li>
-                <li>unsere Konferenz-Publikation <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="blank"><em>Was Bits&Bäume verbindet</em></a>
+                <li>unsere Konferenz-Publikation <a href="https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-baeume-verbindet.html" target="_blank"><em>Was Bits&Bäume verbindet</em></a>
                 </li> 
               </ul>
               
                 <h2>Was wächst</h2>
                 <ul>
-                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="blank">nachhaltig organisieren</a>: Tipps des B&B-Teams, um einzelne Veranstaltungen oder ganze Konferenzen nachhaltig zu machen</a>
+                <li><a href="https://bits-und-baeume.org/infrastruktur/de" target="_blank">nachhaltig organisieren</a>: Tipps des B&B-Teams, um einzelne Veranstaltungen oder ganze Konferenzen nachhaltig zu machen</a>
                 </li>  
-                <li><a href="/material/<?php echo $lang; ?>" target="blank">B&B-Material</a> für deine eignen Aktionen (Logo bis Sticker)
+                <li><a href="/material/<?php echo $lang; ?>" target="_blank">B&B-Material</a> für deine eignen Aktionen (Logo bis Sticker)
                 </li> 
-                <li>neue Triebe: <a href="/regionalzweige/<?php echo $lang; ?>" target="blank">Stammtische</a>
+                <li>neue Triebe: <a href="/regionalzweige/<?php echo $lang; ?>" target="_blank">Stammtische</a>
                 </li>
               </ul>
   


### PR DESCRIPTION
Replace all blank targets with `_blank` since all these links are opened in the same window/tab and overwrite previously opened links. I am guessing this was just a typo in the previous target attributes.